### PR TITLE
PLXCOMP-234: remove deprecated TarOptions mode handling

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/tar/TarArchiver.java
@@ -74,41 +74,8 @@ public class TarArchiver
     public void setOptions( TarOptions options )
     {
         this.options = options;
-
-        // FIXME: do these options have precedence over
-        // setDefaultFileMode / setDefaultDirMode
-        // or the other way around? Assuming these
-        // take precedende since they're more specific.
-        // Better refactor this when usage is known.
-
-        setDefaultFileMode( options.getMode() );
-
-        setDefaultDirectoryMode( options.getMode() );
     }
 
-//    /**
-//     * Override AbstractArchiver.setDefaultFileMode to
-//     * update TarOptions.
-//     */
-//    public void setDefaultFileMode( int mode )
-//    {
-//        super.setDefaultFileMode( mode );
-//
-//        options.setMode( mode );
-//    }
-//
-//    /**
-//     * Override AbstractArchiver.setDefaultDirectoryMode to
-//     * update TarOptions.
-//     */
-//    public void setDefaultDirectoryMode( int mode )
-//    {
-//        super.setDefaultDirectoryMode( mode );
-//
-//        options.setDirMode( mode );
-//    }
-//
-//
     /**
      * Set how to handle long files, those with a path&gt;100 chars.
      * Optional, default=warn.
@@ -381,16 +348,6 @@ public class TarArchiver
      */
     public class TarOptions
     {
-        /**
-         * @deprecated
-         */
-        private int fileMode = UnixStat.FILE_FLAG | UnixStat.DEFAULT_FILE_PERM;
-
-        /**
-         * @deprecated
-         */
-        private int dirMode = UnixStat.DIR_FLAG | UnixStat.DEFAULT_DIR_PERM;
-
         private String userName = "";
 
         private String groupName = "";
@@ -400,70 +357,6 @@ public class TarArchiver
         private int gid;
 
         private boolean preserveLeadingSlashes = false;
-
-        /**
-         * A 3 digit octal string, specify the user, group and
-         * other modes in the standard Unix fashion;
-         * optional, default=0644
-         *
-         * @param octalString a 3 digit octal string.
-         * @deprecated use AbstractArchiver.setDefaultFileMode(int)
-         */
-        public void setMode( String octalString )
-        {
-            setMode( Integer.parseInt( octalString, 8 ) );
-        }
-
-        /**
-         * @param mode unix file mode
-         * @deprecated use AbstractArchiver.setDefaultFileMode(int)
-         */
-        public void setMode( int mode )
-        {
-            this.fileMode = UnixStat.FILE_FLAG | ( mode & UnixStat.PERM_MASK );
-        }
-
-        /**
-         * @return the current mode.
-         * @deprecated use AbstractArchiver.getDefaultFileMode()
-         */
-        public int getMode()
-        {
-            return fileMode;
-        }
-
-        /**
-         * A 3 digit octal string, specify the user, group and
-         * other modes in the standard Unix fashion;
-         * optional, default=0755
-         *
-         * @param octalString a 3 digit octal string.
-         * @since Ant 1.6
-         * @deprecated use AbstractArchiver.setDefaultDirectoryMode(int)
-         */
-        public void setDirMode( String octalString )
-        {
-            setDirMode( Integer.parseInt( octalString, 8 ) );
-        }
-
-        /**
-         * @param mode unix directory mode
-         * @deprecated use AbstractArchiver.setDefaultDirectoryMode(int)
-         */
-        public void setDirMode( int mode )
-        {
-            this.dirMode = UnixStat.DIR_FLAG | ( mode & UnixStat.PERM_MASK );
-        }
-
-        /**
-         * @return the current directory mode
-         * @since Ant 1.6
-         * @deprecated use AbstractArchiver.getDefaultDirectoryMode()
-         */
-        public int getDirMode()
-        {
-            return dirMode;
-        }
 
         /**
          * The username for the tar entry
@@ -585,7 +478,6 @@ public class TarArchiver
          * BZIP2 compression
          */
         private static final String BZIP2 = "bzip2";
-
 
         /**
          * Default constructor

--- a/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
+++ b/src/test/java/org/codehaus/plexus/archiver/tar/TarArchiverTest.java
@@ -272,20 +272,28 @@ public class TarArchiverTest
     public void testCreateArchive()
         throws Exception
     {
+        createArchive(0500, new int[] {0400, 0640, 0664});
+        createArchive(0500, new int[] {0400, 0640, 0664});
+    }
+
+    public void createArchive(final int directoryMode, final int fileModes[])
+        throws Exception
+    {
+        int defaultFileMode = fileModes[0];
+        int oneFileMode = fileModes[1];
+        int twoFileMode = fileModes[2];
+
         TarArchiver archiver = (TarArchiver) lookup( Archiver.ROLE, "tar" );
 
-        archiver.setDirectoryMode( 0500 );
-        archiver.getOptions().setDirMode( 0500 );
+        archiver.setDirectoryMode( directoryMode );
 
-        archiver.setFileMode( 0400 );
-        archiver.getOptions().setMode( 0400 );
+        archiver.setFileMode( defaultFileMode );
 
         archiver.addDirectory( getTestFile( "src" ) );
-        archiver.setFileMode( 0640 );
-        archiver.getOptions().setMode( 0640 );
+        archiver.setFileMode( oneFileMode );
 
         archiver.addFile( getTestFile( "src/test/resources/manifests/manifest1.mf" ), "one.txt" );
-        archiver.addFile( getTestFile( "src/test/resources/manifests/manifest2.mf" ), "two.txt", 0664 );
+        archiver.addFile( getTestFile( "src/test/resources/manifests/manifest2.mf" ), "two.txt", twoFileMode );
         archiver.setDestFile( getTestFile( "target/output/archive.tar" ) );
         archiver.createArchive();
 
@@ -298,21 +306,21 @@ public class TarArchiverTest
         {
             if ( te.isDirectory() )
             {
-                assertEquals( 0500, te.getMode() & UnixStat.PERM_MASK );
+                assertEquals( directoryMode, te.getMode() & UnixStat.PERM_MASK );
             }
             else
             {
                 if ( te.getName().equals( "one.txt" ) )
                 {
-                    assertEquals( 0640, te.getMode() & UnixStat.PERM_MASK );
+                    assertEquals( oneFileMode, te.getMode() & UnixStat.PERM_MASK );
                 }
                 else if ( te.getName().equals( "two.txt" ) )
                 {
-                    assertEquals( 0664, te.getMode() & UnixStat.PERM_MASK );
+                    assertEquals( twoFileMode, te.getMode() & UnixStat.PERM_MASK );
                 }
                 else
                 {
-                    assertEquals( 0400, te.getMode() & UnixStat.PERM_MASK );
+                    assertEquals( defaultFileMode, te.getMode() & UnixStat.PERM_MASK );
                 }
 
             }


### PR DESCRIPTION
Changing the mode of files/directories added to tar archives via
TarOptions is deprecated and is not working correctly in all cases.

This commit removes the deprecated methods and class variables as well
as the partial workaround for incorrect handling of modes that had been
set via TarOptions.
