### PR TITLE
Allow support for Java 9, which reports "9" as "java.version"

### DIFF
--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
@@ -116,8 +116,8 @@ public abstract class AbstractZipArchiver
     private static final boolean isJava7OrLower;
 
     static {
-        Matcher m = Pattern.compile("(?:1\\.)?(\\d+)").matcher(System.getProperty("java.version"));
-        if (! m.matches()) {
+        Matcher m = Pattern.compile("^(?:1\\.)?(\\d+)").matcher(System.getProperty("java.version"));
+        if (! m.find()) {
             throw new IllegalStateException("Invalid Java version");	
         }
         isJava7OrLower = Integer.parseInt(m.group(1)) <= 7;

--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
@@ -113,7 +113,15 @@ public abstract class AbstractZipArchiver
 	 * Java versions from 8 and up round timestamp up.
 	 * s
      */
-    private static final boolean isJava7OrLower = Integer.parseInt(System.getProperty("java.version").split("\\.")[1]) <= 7;
+    private static final boolean isJava7OrLower;
+
+    static {
+        Matcher m = Pattern.compile("(?:1\\.)?(\\d+)").matcher(System.getProperty("java.version"));
+        if (! m.matches()) {
+            throw new IllegalStateException("Invalid Java version");	
+    	}
+    	isJava7OrLower = Integer.parseInt(m.group(1)) <= 7;
+    }
 
 	// Renamed version of original file, if it exists
     private File renamedFile = null;

--- a/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
+++ b/src/main/java/org/codehaus/plexus/archiver/zip/AbstractZipArchiver.java
@@ -119,8 +119,8 @@ public abstract class AbstractZipArchiver
         Matcher m = Pattern.compile("(?:1\\.)?(\\d+)").matcher(System.getProperty("java.version"));
         if (! m.matches()) {
             throw new IllegalStateException("Invalid Java version");	
-    	}
-    	isJava7OrLower = Integer.parseInt(m.group(1)) <= 7;
+        }
+        isJava7OrLower = Integer.parseInt(m.group(1)) <= 7;
     }
 
 	// Renamed version of original file, if it exists


### PR DESCRIPTION
Use a regular expression to match either 1.x or x version patterns.
